### PR TITLE
Fix singleuser

### DIFF
--- a/config/jupyter/before_notebook.sh
+++ b/config/jupyter/before_notebook.sh
@@ -3,8 +3,8 @@
 # For global startup script, see ./config/jupyter/jupterlab_startup.sh
 
 # Overrides Dockerfile changes to NB_USER
-/usr/bin/printf '%s\n%s\n' 'password' 'password' | passwd ${NB_USER}
-usermod --shell /bin/bash ${NB_USER}
+sudo /usr/bin/printf '%s\n%s\n' 'password' 'password' | passwd ${NB_USER}
+sudo usermod --shell /bin/bash ${NB_USER}
 
 
 # Make sure binfmt_misc is mounted in the place apptainer expects it. This is most likely a bug in apptainer and is a workaround for now on apple silicon when CVMFS is disabled.

--- a/config/jupyter/before_notebook.sh
+++ b/config/jupyter/before_notebook.sh
@@ -1,6 +1,3 @@
-# This script runs in local Jupyterlab only (e.g. Docker, Neurodeskapp)
-# This script does NOT run on stock JupterHub/BinderHub instances (e.g. kubernetes)
-# For global startup script, see ./config/jupyter/jupterlab_startup.sh
 
 if [ "$EUID" -eq 0 ]; then
     # # Overrides Dockerfile changes to NB_USER

--- a/config/jupyter/before_notebook.sh
+++ b/config/jupyter/before_notebook.sh
@@ -2,9 +2,9 @@
 # This script does NOT run on stock JupterHub/BinderHub instances (e.g. kubernetes)
 # For global startup script, see ./config/jupyter/jupterlab_startup.sh
 
-# Overrides Dockerfile changes to NB_USER
-sudo /usr/bin/printf '%s\n%s\n' 'password' 'password' | passwd ${NB_USER}
-sudo usermod --shell /bin/bash ${NB_USER}
+# # Overrides Dockerfile changes to NB_USER
+# /usr/bin/printf '%s\n%s\n' 'password' 'password' | passwd ${NB_USER}
+# usermod --shell /bin/bash ${NB_USER}
 
 
 # Make sure binfmt_misc is mounted in the place apptainer expects it. This is most likely a bug in apptainer and is a workaround for now on apple silicon when CVMFS is disabled.

--- a/config/jupyter/before_notebook.sh
+++ b/config/jupyter/before_notebook.sh
@@ -2,95 +2,96 @@
 # This script does NOT run on stock JupterHub/BinderHub instances (e.g. kubernetes)
 # For global startup script, see ./config/jupyter/jupterlab_startup.sh
 
-# # Overrides Dockerfile changes to NB_USER
-# /usr/bin/printf '%s\n%s\n' 'password' 'password' | passwd ${NB_USER}
-# usermod --shell /bin/bash ${NB_USER}
+if [ "$EUID" -eq 0 ]; then
+    # # Overrides Dockerfile changes to NB_USER
+    # /usr/bin/printf '%s\n%s\n' 'password' 'password' | passwd ${NB_USER}
+    # usermod --shell /bin/bash ${NB_USER}
 
-
-# Make sure binfmt_misc is mounted in the place apptainer expects it. This is most likely a bug in apptainer and is a workaround for now on apple silicon when CVMFS is disabled.
-if [ -d "/proc/sys/fs/binfmt_misc" ]; then
-    # Check if binfmt_misc is already mounted
-    if ! mountpoint -q /proc/sys/fs/binfmt_misc; then
-        echo "binfmt_misc directory exists but is not mounted. Mounting now..."
-        sudo mount -t binfmt_misc binfmt /proc/sys/fs/binfmt_misc
+    # Make sure binfmt_misc is mounted in the place apptainer expects it. This is most likely a bug in apptainer and is a workaround for now on apple silicon when CVMFS is disabled.
+    if [ -d "/proc/sys/fs/binfmt_misc" ]; then
+        # Check if binfmt_misc is already mounted
+        if ! mountpoint -q /proc/sys/fs/binfmt_misc; then
+            echo "binfmt_misc directory exists but is not mounted. Mounting now..."
+            sudo mount -t binfmt_misc binfmt /proc/sys/fs/binfmt_misc
+        else
+            echo "binfmt_misc is already mounted."
+        fi
     else
-        echo "binfmt_misc is already mounted."
-    fi
-else
-    echo "binfmt_misc directory does not exist in /proc/sys/fs."
-fi
-
-if [ ! -d "/cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/" ]; then
-    # the cvmfs directory is not yet mounted
-
-    # check if we have internet connectivity:
-    if ping -q -c 1 -W 1 google.com >/dev/null; then
-        echo "Internet is up"
-    else
-        export CVMFS_DISABLE=true
-        echo "No internet connection. Disabling CVMFS."
+        echo "binfmt_misc directory does not exist in /proc/sys/fs."
     fi
 
-    # This is to capture legacy use. If CVMFS_DISABLE is not set, we assume it is false, which was the legacy behaviour.
-    if [ -z "$CVMFS_DISABLE" ]; then
-        export CVMFS_DISABLE="false"
-    fi
+    if [ ! -d "/cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/" ]; then
+        # the cvmfs directory is not yet mounted
+
+        # check if we have internet connectivity:
+        if ping -q -c 1 -W 1 google.com >/dev/null; then
+            echo "Internet is up"
+        else
+            export CVMFS_DISABLE=true
+            echo "No internet connection. Disabling CVMFS."
+        fi
+
+        # This is to capture legacy use. If CVMFS_DISABLE is not set, we assume it is false, which was the legacy behaviour.
+        if [ -z "$CVMFS_DISABLE" ]; then
+            export CVMFS_DISABLE="false"
+        fi
 
 
-    if [[ "$CVMFS_DISABLE" == "false" ]]; then
-        # CVMFS_DISABLE is false and CVMFS should be enabled.
+        if [[ "$CVMFS_DISABLE" == "false" ]]; then
+            # CVMFS_DISABLE is false and CVMFS should be enabled.
 
-        # try to list the directory in case it's autofs mounted outside
-        ls /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ 2>/dev/null && echo "CVMFS is ready" || echo "CVMFS directory not there. Trying internal fuse mount next."
+            # try to list the directory in case it's autofs mounted outside
+            ls /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ 2>/dev/null && echo "CVMFS is ready" || echo "CVMFS directory not there. Trying internal fuse mount next."
 
-        if [ ! -d "/cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/" ]; then
-            # it is not available outside, so try mounting with fuse inside container
+            if [ ! -d "/cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/" ]; then
+                # it is not available outside, so try mounting with fuse inside container
 
-            echo "probing if the latency of direct connection or the latency of a CDN is better"
-            DIRECT=cvmfs-geoproximity.neurodesk.org
-            DIRECT_url="http://${DIRECT}/cvmfs/neurodesk.ardc.edu.au/.cvmfspublished" 
-            CDN=cvmfs.neurodesk.org
-            CDN_url="http://${CDN}/cvmfs/neurodesk.ardc.edu.au/.cvmfspublished"
+                echo "probing if the latency of direct connection or the latency of a CDN is better"
+                DIRECT=cvmfs-geoproximity.neurodesk.org
+                DIRECT_url="http://${DIRECT}/cvmfs/neurodesk.ardc.edu.au/.cvmfspublished" 
+                CDN=cvmfs.neurodesk.org
+                CDN_url="http://${CDN}/cvmfs/neurodesk.ardc.edu.au/.cvmfspublished"
 
-            echo testing $CDN_url
-            echo "Resolving DNS name"
-            resolved_dns=$(dig +short $CDN)
-            echo "[DEBUG]: Resolved DNS for $CDN: $resolved_dns"
-            CDN_url_latency=$(curl -s -w %{time_total}\\n -o /dev/null "$CDN_url")
-            echo $CDN_url_latency
-            
-            echo testing $DIRECT_url
-            echo "Resolving DNS name"
-            resolved_dns=$(dig +short $DIRECT)
-            echo "[DEBUG]: Resolved DNS for $DIRECT: $resolved_dns"
-            DIRECT_url_latency=$(curl -s -w %{time_total}\\n -o /dev/null "$DIRECT_url")
-            echo $DIRECT_url_latency
+                echo testing $CDN_url
+                echo "Resolving DNS name"
+                resolved_dns=$(dig +short $CDN)
+                echo "[DEBUG]: Resolved DNS for $CDN: $resolved_dns"
+                CDN_url_latency=$(curl -s -w %{time_total}\\n -o /dev/null "$CDN_url")
+                echo $CDN_url_latency
+                
+                echo testing $DIRECT_url
+                echo "Resolving DNS name"
+                resolved_dns=$(dig +short $DIRECT)
+                echo "[DEBUG]: Resolved DNS for $DIRECT: $resolved_dns"
+                DIRECT_url_latency=$(curl -s -w %{time_total}\\n -o /dev/null "$DIRECT_url")
+                echo $DIRECT_url_latency
 
-            if (( $(echo "$DIRECT_url_latency < $CDN_url_latency" |bc -l) )); then
-                echo "Direct connection is faster"
-                cp /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf.direct /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
-            else
-                echo "CDN is faster"
-                cp /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf.cdn /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
-            fi
-
-            echo "\
-            ==================================================================
-            Mounting CVMFS"
-            if ( service autofs status > /dev/null ); then
-                 echo "autofs is running - not attempting to mount manually:"
-                 ls /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ 2>/dev/null && echo "CVMFS is ready after autofs mount" || echo "AutoFS not working!"
-            else
-                echo "autofs is NOT running - attempting to mount manually:"
-                mkdir -p /cvmfs/neurodesk.ardc.edu.au
-                mount -t cvmfs neurodesk.ardc.edu.au /cvmfs/neurodesk.ardc.edu.au
-
-                ls /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ 2>/dev/null && echo "CVMFS is ready after manual mount" || echo "Manual CVMFS mount not successful"
+                if (( $(echo "$DIRECT_url_latency < $CDN_url_latency" |bc -l) )); then
+                    echo "Direct connection is faster"
+                    cp /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf.direct /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
+                else
+                    echo "CDN is faster"
+                    cp /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf.cdn /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
+                fi
 
                 echo "\
                 ==================================================================
-                CVMFS servers:"
-                cvmfs_talk -i neurodesk.ardc.edu.au host info
+                Mounting CVMFS"
+                if ( service autofs status > /dev/null ); then
+                    echo "autofs is running - not attempting to mount manually:"
+                    ls /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ 2>/dev/null && echo "CVMFS is ready after autofs mount" || echo "AutoFS not working!"
+                else
+                    echo "autofs is NOT running - attempting to mount manually:"
+                    mkdir -p /cvmfs/neurodesk.ardc.edu.au
+                    mount -t cvmfs neurodesk.ardc.edu.au /cvmfs/neurodesk.ardc.edu.au
+
+                    ls /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ 2>/dev/null && echo "CVMFS is ready after manual mount" || echo "Manual CVMFS mount not successful"
+
+                    echo "\
+                    ==================================================================
+                    CVMFS servers:"
+                    cvmfs_talk -i neurodesk.ardc.edu.au host info
+                fi
             fi
         fi
     fi

--- a/config/jupyter/jupyterlab_startup.sh
+++ b/config/jupyter/jupyterlab_startup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# This script runs globally (e.g. Docker, Neurodeskapp, JupyterHub, BinderHub)
-# For local Jupyterlab only, see ./config/jupyter/before_notebook.sh
-
 # Copy homedirectory files if they don't exist yet
 # Check for missing conda-readme.md in persisting homedir
 if [ ! -f "${HOME}/conda-readme.md" ] 

--- a/config/jupyter/start_notebook.sh
+++ b/config/jupyter/start_notebook.sh
@@ -1,6 +1,3 @@
-# This script runs in local Jupyterlab only (e.g. Docker, Neurodeskapp)
-# This script does NOT run on stock JupterHub/BinderHub instances (e.g. kubernetes)
-# For global startup script, see ./config/jupyter/jupterlab_startup.sh
 
 if [ -z "$GRANT_SUDO" ]; then
 export GRANT_SUDO='yes'


### PR DESCRIPTION
Fixing notebook startup on k8s for base-notebook >= 2024-12-03
- Using workaround for notebooks started as non-root (e.g. k8s)
- base-notebooks from 2025-01-24 now run before_notebook.sh and start_notebook.sh scripts in singleuser mode.
