### PR TITLE
Simplified webapp config schema and fixed React Router URL handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -293,13 +293,13 @@ COPY --chown=root:users config/jupyter/webapp_wrapper /opt/neurodesktop/webapp_w
 COPY --chown=root:users config/jupyter/webapp_launcher.sh /opt/neurodesktop/webapp_launcher.sh
 COPY --chown=root:users config/jupyter/jupyter_notebook_config.py.template /opt/neurodesktop/jupyter_notebook_config.py.template
 
-# Fetch webapps.json and generate jupyter config
+# Fetch webapps.json from neurocommand and generate jupyter config
 RUN curl -fsSL https://raw.githubusercontent.com/neurodesk/neurocommand/main/neurodesk/webapps.json \
-    -o /opt/neurodesktop/webapps.json || echo '{"version":"1.0","webapps":{}}' > /opt/neurodesktop/webapps.json
-RUN python3 /opt/neurodesktop/scripts/generate_jupyter_config.py \
-    /opt/neurodesktop/webapps.json \
-    /opt/neurodesktop/jupyter_notebook_config.py.template \
-    /etc/jupyter/jupyter_notebook_config.py
+        -o /opt/neurodesktop/webapps.json \
+    && python3 /opt/neurodesktop/scripts/generate_jupyter_config.py \
+        /opt/neurodesktop/webapps.json \
+        /opt/neurodesktop/jupyter_notebook_config.py.template \
+        /etc/jupyter/jupyter_notebook_config.py
 
 RUN chmod +rx /etc/jupyter/jupyter_notebook_config.py \
     /opt/neurodesktop/jupyterlab_startup.sh \

--- a/scripts/generate_jupyter_config.py
+++ b/scripts/generate_jupyter_config.py
@@ -48,12 +48,18 @@ def generate_server_proxy_entries(webapps: Dict[str, Any]) -> str:
   }}"""
         entries.append(entry)
 
-        # Additional proxy entries (e.g., API endpoints)
+        # Additional proxy entries - only register separately if they're NOT under the app's path
+        # Routes under the app path (e.g., ezbids/api) are handled by the main entry
         for proxy in config.get("additional_proxies", []):
-            proxy_entry = f"""  '{proxy['name']}': {{
-    'port': {proxy['port']},
+            proxy_path = proxy['path']
+            # Skip if the proxy path is under the main app path (will be handled by main entry)
+            if proxy_path.startswith(f"{name}/"):
+                continue
+            proxy_entry = f"""  '{proxy_path}': {{
+    'command': ['/opt/neurodesktop/webapp_launcher.sh', '{name}'],
+    'unix_socket': '{socket_path}',
     'timeout': {startup_timeout},
-    'absolute_url': False,
+    'absolute_url': True,
     'launcher_entry': {{
       'enabled': False
     }}


### PR DESCRIPTION
Simplifies the webapp configuration schema and improves compatibility with single-page applications.

Schema changes:
- `port` is now a direct field instead of nested under `ports.main`
- `additional_proxies` use `path` instead of `name` for clarity

React Router / SPA fixes:
- Injects `<base href>` tag into HTML responses so relative asset URLs resolve correctly
- Adds `history.replaceState()` script to rewrite the URL path, allowing client-side routing frameworks to work properly when served under a subpath like `/appname/`

Reliability fix:
- Binds to the Unix socket before starting the container thread, preventing a race condition where requests could arrive before the socket was ready