### PR TITLE
Potential fix for code scanning alert no. 27: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/notebook_(FSL_bet)_workflow.yml
+++ b/.github/workflows/notebook_(FSL_bet)_workflow.yml
@@ -12,38 +12,38 @@ jobs:
       matrix:
         include:
           - server_name: "Neuro-Test CI VM"
-            token_secret: "JUPYTER_CI_TEST_TOKEN"
+            user_token: ${{ secrets.JUPYTER_CI_TEST_TOKEN }}
             url_var: "JUPYTER_API_URL_CI_TEST"
             default_url: "https://neuro-test.ssdsorg.cloud.edu.au"
             user_var: "JUPYTER_TEST_USER"
             default_user: "akshitbeniwal"
           - server_name: "play-eu"
-            token_secret: "JUPYTER_PLAY_EU_TOKEN"
+            user_token: ${{ secrets.JUPYTER_PLAY_EU_TOKEN }}
             url_var: "JUPYTER_API_URL_PLAY_EU"
             default_url: "https://play-europe.neurodesk.org"
             user_var: "JUPYTER_TEST_USER"
             default_user: "akshitbeniwal"
           - server_name: "play-america"
-            token_secret: "JUPYTER_PLAY_AMERICA_TOKEN"
+            user_token: ${{ secrets.JUPYTER_PLAY_AMERICA_TOKEN }}
             url_var: "JUPYTER_API_URL_PLAY_AMERICA"
             default_url: "https://play-america.neurodesk.org"
             user_var: "JUPYTER_TEST_USER"
             default_user: "akshitbeniwal"
           - server_name: "play-aus"
-            token_secret: "JUPYTER_PLAY_AUS_TOKEN"
+            user_token: ${{ secrets.JUPYTER_PLAY_AUS_TOKEN }}
             url_var: "JUPYTER_API_URL_PLAY_AUS"
             default_url: "https://play.neurodesk.cloud.edu.au"
             user_var: "JUPYTER_TEST_USER_AUS"
             default_user: "aaf_ttacrdwkv3giggp5janknefwxscf9_dmbvilqynah0e"
           - server_name: "edu-neurodesk"
-            token_secret: "JUPYTER_EDU_NEURODESK_TOKEN"
+            user_token: ${{ secrets.JUPYTER_EDU_NEURODESK_TOKEN }}
             url_var: "JUPYTER_API_URL_EDU_NEURODESK"
             default_url: "https://edu.neurodesk.org"
             user_var: "JUPYTER_TEST_USER"
             default_user: "akshitbeniwal"
     
     env:
-      USER_TOKEN: ${{ secrets[matrix.token_secret] }}
+      USER_TOKEN: ${{ matrix.user_token }}
       USER: ${{ vars[matrix.user_var] || matrix.default_user }}
       API_URL: ${{ vars[matrix.url_var] || matrix.default_url }}
       NOTEBOOK_NAME: "FSL_course_bet_test.ipynb"


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurodesktop/security/code-scanning/27](https://github.com/neurodesk/neurodesktop/security/code-scanning/27)

To fix this without changing behavior, replace dynamic secret-name indirection with explicit matrix fields that directly reference each secret expression. Then consume that matrix value in `env.USER_TOKEN`.

Best approach in this file:
- In each `matrix.include` entry, remove `token_secret: "..."`.
- Add `user_token: ${{ secrets.<EXACT_SECRET_NAME> }}` for that entry.
- Update line 46 from `USER_TOKEN: ${{ secrets[matrix.token_secret] }}` to `USER_TOKEN: ${{ matrix.user_token }}`.

This preserves existing per-server token mapping while allowing GitHub to statically determine which specific secrets are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
