### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/notebook_(FSL_bet)_workflow.yml
+++ b/.github/workflows/notebook_(FSL_bet)_workflow.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 6 * * *'  # Run every 24 hours at 6 AM UTC
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   test-notebooks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurodesktop/security/code-scanning/29](https://github.com/neurodesk/neurodesktop/security/code-scanning/29)

Add an explicit `permissions` block at the workflow root (best here since there is one job and it applies cleanly to all steps).  
Use least privilege while preserving behavior:

- `contents: read` (recommended minimum for checkout/read operations)
- `issues: write` (required by the issue-creation action)

Edit file: `.github/workflows/notebook_(FSL_bet)_workflow.yml`  
Region: immediately after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
