### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jupyter_test_main.yml
+++ b/.github/workflows/jupyter_test_main.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 0 * * *'  # Run every 24 hours at midnight UTC
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   test-jupyterhub:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurodesktop/security/code-scanning/33](https://github.com/neurodesk/neurodesktop/security/code-scanning/33)

Add an explicit `permissions:` block to the workflow so token scopes are minimized and documented.  
Best fix here: define permissions at the workflow root (applies to all jobs) with only what this workflow needs:

- `contents: read` (needed for `actions/checkout`)
- `issues: write` (needed by `create-an-issue` step)

This preserves existing behavior (checkout still works, issue creation still works on failure) while removing implicit/default broad permissions.

Change location: `.github/workflows/jupyter_test_main.yml`, directly after the `on:` trigger block and before `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
