### PR TITLE
Fix litellm CVE without breaking pip resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -475,7 +475,6 @@ RUN /opt/conda/bin/pip install \
     jupyterlmod \
     jupyterlab-git \
     notebook_intelligence \
-    "litellm>=1.83.7" \
     jupyterlab_rise \
     jupyterlab-niivue==0.2.5 \
     jupyterlab_myst \
@@ -495,6 +494,7 @@ RUN /opt/conda/bin/pip install \
     bash_kernel \
     "requests>=2.32.3" \
     "chardet<6" \
+    && /opt/conda/bin/pip install --upgrade "litellm>=1.83.7" \
     && /opt/conda/bin/python -m bash_kernel.install --sys-prefix \
     && /opt/conda/bin/jupyter labextension disable @jupyterlab/apputils-extension:announcements \
     && rm -rf /home/${NB_USER}/.cache


### PR DESCRIPTION
## Summary

The previous fix for CVE-2026-42208 added `"litellm>=1.83.7"` next to `notebook_intelligence` in the main `pip install` block. That combined constraint caused pip's resolver to backtrack on every other dependency — eventually reaching `nf-core==1.8` (from 2020), whose `setup.py` has a malformed `setuptools>=38.6.` (trailing dot) version specifier that pip's PEP 440 parser rejects. The amd64 build failed at this step in run [25459327583](https://github.com/neurodesk/neurodesktop/actions/runs/25459327583).

This change moves the litellm upgrade to a follow-up `pip install --upgrade` step in the same `RUN` layer. The first resolver pass picks whatever litellm `notebook_intelligence` is happy with; the second forces it to >=1.83.7, satisfying Trivy without dragging the resolver into ancient nf-core territory.

## Test plan

- [ ] Trigger Build neurodesktop on this branch and confirm the `build-image` jobs succeed
- [ ] Confirm `scan-image` (amd64 + arm64) reports 0 CRITICAL vulnerabilities
- [ ] Confirm `notebook_intelligence` still works at runtime (smoke-test in JupyterLab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)