### PR TITLE
Bump aquasecurity/trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/build-neurodesktop-dev.yml
+++ b/.github/workflows/build-neurodesktop-dev.yml
@@ -359,7 +359,7 @@ jobs:
       - name: Pull container image
         run: docker pull $IMAGEID:latest
       - name: Scan container image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGEID }}:latest
           format: table

--- a/.github/workflows/build-neurodesktop-test.yml
+++ b/.github/workflows/build-neurodesktop-test.yml
@@ -424,7 +424,7 @@ jobs:
       - name: Pull container image
         run: docker pull $IMAGEID:${{ matrix.arch }}
       - name: Container image scan (${{ matrix.arch }})
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGEID }}:${{ matrix.arch }}
           format: table

--- a/.github/workflows/build-neurodesktop.yml
+++ b/.github/workflows/build-neurodesktop.yml
@@ -446,7 +446,7 @@ jobs:
       - name: Pull container image
         run: docker pull $IMAGEID:${{ matrix.arch }}
       - name: Container image scan (${{ matrix.arch }})
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGEID }}:${{ matrix.arch }}
           format: table


### PR DESCRIPTION
## Summary

Bumps `aquasecurity/trivy-action` from v0.35.0 → v0.36.0 (released 2026-04-22). v0.35.0 internally referenced `actions/cache@0400d5f6...` which was the source of the residual Node 20 deprecation annotations in the last successful run ([25460066358](https://github.com/neurodesk/neurodesktop/actions/runs/25460066358)) — those should clear in v0.36.0.

Pure version bump, same call signature; the existing `image-ref` / `severity: CRITICAL` / `skip-files` inputs are unchanged.

## Test plan

- [ ] Run Build neurodesktop and confirm scan-image jobs still pass
- [ ] Confirm the "actions/cache@0400... forced to Node 24" annotation is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)