### PR TITLE
[BREAKING] Move prod image to ghcr.io/neurodesk/neurodesktop (shorter GHCR path)

### DIFF
--- a/.github/workflows/build-neurodesktop.yml
+++ b/.github/workflows/build-neurodesktop.yml
@@ -69,7 +69,10 @@ jobs:
         run: |
           IMAGENAME="neurodesktop"
           BUILDDATE=`date +%Y-%m-%d`
-          IMAGEID=ghcr.io/$GITHUB_REPOSITORY/$IMAGENAME
+          # GHCR path = owner + image name (ghcr.io/neurodesk/neurodesktop),
+          # matching the Quay/DockerHub style. Previously $GITHUB_REPOSITORY
+          # (org/repo) made it ghcr.io/neurodesk/neurodesktop/neurodesktop.
+          IMAGEID=ghcr.io/$GITHUB_REPOSITORY_OWNER/$IMAGENAME
           IMAGEID=$(echo $IMAGEID | tr '[A-Z]' '[a-z]')
 
           echo "BUILDDATE=$BUILDDATE"
@@ -155,7 +158,10 @@ jobs:
         run: |
           IMAGENAME="neurodesktop"
           BUILDDATE=`date +%Y-%m-%d`
-          IMAGEID=ghcr.io/$GITHUB_REPOSITORY/$IMAGENAME
+          # GHCR path = owner + image name (ghcr.io/neurodesk/neurodesktop),
+          # matching the Quay/DockerHub style. Previously $GITHUB_REPOSITORY
+          # (org/repo) made it ghcr.io/neurodesk/neurodesktop/neurodesktop.
+          IMAGEID=ghcr.io/$GITHUB_REPOSITORY_OWNER/$IMAGENAME
           IMAGEID=$(echo $IMAGEID | tr '[A-Z]' '[a-z]')
 
           echo "BUILDDATE=$BUILDDATE" >> $GITHUB_ENV
@@ -298,7 +304,10 @@ jobs:
       - name: Set environment variables
         run: |
           IMAGENAME="neurodesktop"
-          IMAGEID=ghcr.io/$GITHUB_REPOSITORY/$IMAGENAME
+          # GHCR path = owner + image name (ghcr.io/neurodesk/neurodesktop),
+          # matching the Quay/DockerHub style. Previously $GITHUB_REPOSITORY
+          # (org/repo) made it ghcr.io/neurodesk/neurodesktop/neurodesktop.
+          IMAGEID=ghcr.io/$GITHUB_REPOSITORY_OWNER/$IMAGENAME
           IMAGEID=$(echo $IMAGEID | tr '[A-Z]' '[a-z]')
           echo "IMAGEID=$IMAGEID" >> $GITHUB_ENV
       - name: Free up build space
@@ -455,7 +464,10 @@ jobs:
       - name: Set environment variables
         run: |
           IMAGENAME="neurodesktop"
-          IMAGEID=ghcr.io/$GITHUB_REPOSITORY/$IMAGENAME
+          # GHCR path = owner + image name (ghcr.io/neurodesk/neurodesktop),
+          # matching the Quay/DockerHub style. Previously $GITHUB_REPOSITORY
+          # (org/repo) made it ghcr.io/neurodesk/neurodesktop/neurodesktop.
+          IMAGEID=ghcr.io/$GITHUB_REPOSITORY_OWNER/$IMAGENAME
           IMAGEID=$(echo $IMAGEID | tr '[A-Z]' '[a-z]')
           echo "IMAGEID=$IMAGEID" >> $GITHUB_ENV
       - name: Free up build space


### PR DESCRIPTION
## What

Publishes the production `neurodesktop` image to `ghcr.io/neurodesk/neurodesktop`
(owner + image name), instead of `ghcr.io/neurodesk/neurodesktop/neurodesktop`.

Same one-line change as the test workflow (#588): build the GHCR path from
`$GITHUB_REPOSITORY_OWNER` (owner) instead of `$GITHUB_REPOSITORY` (owner/repo).
Only GHCR is affected — DockerHub (`vnmd/neurodesktop`) is already in this form.

## Notes for reviewers / admins

- **⚠️ BREAKING change for GHCR pullers: the image moves to a new package path.
  Consumers of `ghcr.io/neurodesk/neurodesktop/neurodesktop` must switch to
  `ghcr.io/neurodesk/neurodesktop`. Planned for the maintenance window with user
  migration — please do NOT merge outside that window.**
- **New GHCR package is private by default — an org owner must set it public and
  link it to the repo after the first push.** The old path keeps its existing tags.
