### PR TITLE
Add one-off workflow to backfill neurodesktop history to Quay

### DIFF
--- a/.github/workflows/backfill-neurodesktop-quay.yml
+++ b/.github/workflows/backfill-neurodesktop-quay.yml
@@ -1,0 +1,145 @@
+name: Backfill neurodesktop history to Quay
+
+# One-off utility (dispatch only). Mirrors the FULL desktop-host neurodesktop
+# history from GHCR into quay.io/neurodesk/neurodesktop, so Quay matches what
+# GHCR/DockerHub already carry. Safe to re-run: tags already present (same
+# digest) are skipped, so it resumes where it left off.
+#
+# Run with dry_run=true first to preview what would be copied. GHCR is the
+# source (no pull rate limits, unlike DockerHub on shared runner IPs):
+#   - old path ghcr.io/neurodesk/neurodesktop/neurodesktop  -> 2021..rename
+#   - new path ghcr.io/neurodesk/neurodesktop               -> rename..now
+# The recipe tags (20260428*) are NOT desktop-host; they are skipped
+# automatically because they 404 on the GHCR source.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only — list tags, copy nothing"
+        type: boolean
+        default: true
+      year_filter:
+        description: "Backfill only this year (e.g. 2024), or 'all'"
+        type: string
+        default: "all"
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  DEST: quay.io/neurodesk/neurodesktop
+  SRC_NEW: ghcr.io/neurodesk/neurodesktop
+  SRC_OLD: ghcr.io/neurodesk/neurodesktop/neurodesktop
+
+jobs:
+  backfill:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 350 # under the 6h hard cap; re-dispatch to resume if needed
+    steps:
+      - name: Install crane
+        run: |
+          curl -sL https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin crane
+          crane version
+
+      - name: Login to GHCR (source)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Quay (destination)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Backfill desktop-host history to Quay
+        shell: bash --noprofile --norc {0}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          YEAR_FILTER: ${{ inputs.year_filter }}
+        run: |
+          set -uo pipefail
+
+          # --- Enumerate source tags. New path wins; old path fills deep history. ---
+          declare -A SRC
+          for t in $(crane ls "$SRC_NEW" 2>/dev/null || true); do SRC["$t"]="$SRC_NEW"; done
+          for t in $(crane ls "$SRC_OLD" 2>/dev/null || true); do
+            [ -z "${SRC[$t]:-}" ] && SRC["$t"]="$SRC_OLD"
+          done
+
+          # --- Keep only dated desktop-host tags: YYYY-MM-DD or legacy YYYYMMDD. ---
+          TAGS=()
+          for t in "${!SRC[@]}"; do
+            if [[ "$t" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || [[ "$t" =~ ^[0-9]{8}$ ]]; then
+              if [ "$YEAR_FILTER" = "all" ] || [ "${t:0:4}" = "$YEAR_FILTER" ]; then
+                TAGS+=("$t")
+              fi
+            fi
+          done
+          if [ "${#TAGS[@]}" -gt 0 ]; then
+            mapfile -t TAGS < <(printf '%s\n' "${TAGS[@]}" | sort)
+          fi
+          echo "Considering ${#TAGS[@]} dated tags (year filter: ${YEAR_FILTER})."
+
+          copied=0; skipped=0; failed=0
+
+          copy_one() {
+            local src="$1" dst="$2" n=1 max=3 to=3600 log
+            while true; do
+              log="$(mktemp)"
+              if timeout "${to}s" crane copy "$src" "$dst" >"$log" 2>&1; then
+                rm -f "$log"; return 0
+              fi
+              if grep -Eiq 'unauthorized|denied|forbidden' "$log"; then
+                echo "::error::auth failure copying ${src} -> ${dst}"; cat "$log"; rm -f "$log"; exit 1
+              fi
+              cat "$log"; rm -f "$log"
+              if [ "$n" -ge "$max" ]; then return 1; fi
+              echo "retry ${n}/${max} for ${src} in $((30 * n))s..."
+              sleep "$((30 * n))"; n="$((n + 1))"
+            done
+          }
+
+          for t in "${TAGS[@]}"; do
+            src="${SRC[$t]}:$t"
+            sdig="$(crane digest "$src" 2>/dev/null || true)"
+            if [ -z "$sdig" ]; then echo "skip (source missing): $t"; skipped=$((skipped + 1)); continue; fi
+            ddig="$(crane digest "${DEST}:${t}" 2>/dev/null || true)"
+            if [ "$sdig" = "$ddig" ]; then echo "skip (already in Quay): $t"; skipped=$((skipped + 1)); continue; fi
+            if [ "$DRY_RUN" = "true" ]; then echo "[dry-run] would copy ${src} -> ${DEST}:${t}"; continue; fi
+            echo "copying ${t} ..."
+            if copy_one "$src" "${DEST}:${t}"; then copied=$((copied + 1)); else echo "::warning::failed ${t}"; failed=$((failed + 1)); fi
+          done
+
+          # --- Set :latest to the current desktop-host latest (newest build). ---
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] would set ${DEST}:latest from ${SRC_NEW}:latest"
+          else
+            echo "setting :latest ..."
+            copy_one "${SRC_NEW}:latest" "${DEST}:latest" || echo "::warning::failed to set latest"
+          fi
+
+          {
+            echo "## Backfill summary"
+            echo "- mode: $([ "$DRY_RUN" = "true" ] && echo dry-run || echo live)"
+            echo "- year filter: ${YEAR_FILTER}"
+            echo "- considered: ${#TAGS[@]}"
+            echo "- copied: ${copied}"
+            echo "- skipped: ${skipped}"
+            echo "- failed: ${failed}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$failed" -eq 0 ]
+
+      - name: Verify Quay dated-tag count
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          n=$(crane ls "$DEST" | grep -Ec '^[0-9]{4}-[0-9]{2}-[0-9]{2}$|^[0-9]{8}$') || n=0
+          echo "Quay now has ${n} dated tags."
+          echo "- Quay dated tags after run: ${n}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds a **dispatch-only** utility workflow that mirrors the full desktop-host `neurodesktop` history from GHCR into `quay.io/neurodesk/neurodesktop`, so Quay matches what GHCR/DockerHub already carry.

- **Source:** GHCR (old `…/neurodesktop/neurodesktop` for 2021→rename + new path for rename→now) — no pull rate limits.
- **`dry_run` defaults to true** — preview before any copy.
- **Resumable** — skips tags already present (same digest); dead recipe `20260428*` tags 404 on source and are skipped automatically.
- `crane copy` preserves multi-arch manifests; 60-min timeout + retries for the large images; `year_filter` to batch under the 6h job cap.

One-off; not on any schedule. Run `dry_run: true` first, then `dry_run: false`.
