### PR TITLE
Ship proot runtime libs (libtalloc2, libprotobuf-c1) for rootless apptainer builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,11 +230,17 @@ ENV LC_ALL=""
 # Launchpad API/PPA path and lets us pin scanner-fixed Go module/toolchain levels
 # before upstream publishes a matching multi-arch runtime image.
 COPY --from=apptainer /opt/apptainer /opt/apptainer
+# apptainer is built --with-suid but runs setuid-DISABLED (see the apptainer.conf edit below), so
+# unprivileged image builds fall back to the bundled proot (libexec/apptainer/bin/proot). proot is
+# dynamically linked and, because it's vendored (not apt-installed), nothing pulls in its runtime
+# libs. Ship libtalloc2 + libprotobuf-c1 so the proot fallback works on hosts/sessions without user
+# namespaces — otherwise `apptainer build` / `singularity` fails at the mksquashfs step with
+# "proot: error while loading shared libraries: libtalloc.so.2 / libprotobuf-c.so.1".
 RUN ln -sf /opt/apptainer/bin/apptainer /usr/local/bin/apptainer \
     && ln -sf /opt/apptainer/bin/singularity /usr/local/bin/singularity \
     && rm -rf /opt/apptainer/libexec/apptainer/cni \
     && sed -i 's/^allow setuid = yes/allow setuid = no/' /opt/apptainer/etc/apptainer/apptainer.conf \
-    && apt-install-retry fuse-overlayfs squashfuse \
+    && apt-install-retry fuse-overlayfs squashfuse libtalloc2 libprotobuf-c1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && rm -rf /root/.cache && rm -rf /home/${NB_USER}/.cache
 


### PR DESCRIPTION
## Problem

On a `neurodesktop` session **without user namespaces**, building/pulling an apptainer image from a `docker://` URI fails at the final SIF step:

```
INFO:    Creating SIF file...
FATAL:   ... while creating squashfs: /opt/apptainer/libexec/apptainer/bin/mksquashfs command failed:
         exit status 127: /opt/apptainer/libexec/apptainer/bin/proot: error while loading shared libraries:
         libtalloc.so.2: cannot open shared object file: No such file or directory
```

After installing `libtalloc2` it moves to the next missing lib, `libprotobuf-c.so.1`; with both present it works.

## Root cause

apptainer here is built `--with-suid` but runs **setuid-disabled** (`sed -i 's/^allow setuid = yes/allow setuid = no/'` in the Dockerfile). So unprivileged image builds fall back to the **bundled `proot`** (`libexec/apptainer/bin/proot`). `proot` is dynamically linked against `libtalloc.so.2` and `libprotobuf-c.so.1`, but because it's **vendored** (copied in from the build stage, not `apt`-installed) nothing declares those runtime deps — so a minimized base image never pulls them in. They also stay invisible on any host that *does* have user namespaces, because then apptainer uses its native build path and never touches `proot`.

## Fix

Add the two runtime libs next to apptainer's other runtime helpers (`fuse-overlayfs squashfuse`). They're ~110 KB combined, both in Ubuntu `main` (`libtalloc2` LGPL, `libprotobuf-c1` BSD).

```diff
-    && apt-install-retry fuse-overlayfs squashfuse \
+    && apt-install-retry fuse-overlayfs squashfuse libtalloc2 libprotobuf-c1 \
```

This makes the rootless proot fallback work out of the box for sessions without user namespaces. (The cleaner root-cause alternative — enabling unprivileged user namespaces so apptainer never needs proot — is environment-dependent; this change is a cheap belt-and-braces that helps regardless.)

Encountered while running containerized QSM reconstructions (`qsm-ci run … --runner apptainer`) on neurodesktop.