### PR TITLE
Harden CVMFS cold-cache negative test

### DIFF
--- a/tests/container/test_cvmfs_tools.py
+++ b/tests/container/test_cvmfs_tools.py
@@ -11,6 +11,12 @@ _ENV_PREAMBLE = (
     "source /usr/share/lmod/lmod/init/bash 2>/dev/null; "
 )
 
+# A negative Lmod lookup must traverse every MODULEPATH entry. On a fresh
+# runner those entries are backed by a cold CVMFS catalogue and can take longer
+# than the normal command limit; five minutes still bounds a genuinely stuck
+# mount while avoiding a false failure during the first catalogue traversal.
+_CVMFS_COLD_CACHE_TIMEOUT = 300
+
 
 def run_cmd(cmd, timeout=120):
     """Run a shell command and return (exit_code, output). Kills process group on timeout."""
@@ -117,7 +123,10 @@ class TestFslMaths:
         """Loading a non-existent module should fail with non-zero exit code."""
         _skip_if_cvmfs_disabled()
 
-        code, output = run_neuro_cmd("module load funny-name-tool")
+        code, output = run_neuro_cmd(
+            "module load funny-name-tool",
+            timeout=_CVMFS_COLD_CACHE_TIMEOUT,
+        )
         assert code != 0, (
             f"Loading non-existent module should have failed but exited 0: {output}"
         )


### PR DESCRIPTION
## What changed

- give the CVMFS-backed missing-module assertion a dedicated 300-second cold-cache timeout
- retain the normal 120-second timeout for every other command
- document why the wider bound is specific to the first negative Lmod catalogue traversal

## Why

Issue #815 recorded a scheduled build where `module load funny-name-tool` reached the generic 120-second limit on a cold CVMFS runner. The same lookup paths passed later in that container, in the peer matrix job, and in the prior nightly. Five minutes avoids that false failure while still bounding an unhealthy mount.

Fixes #815.

## Validation

- `python -m py_compile tests/container/test_cvmfs_tools.py`
- `CVMFS_DISABLE=true pytest -q tests/container/test_cvmfs_tools.py` (6 expected skips outside the image)
- `pytest -q tests/unit` (329 passed)
- [`Build neurodesktop-test` run 31342033727](https://github.com/neurodesk/neurodesktop/actions/runs/31342033727) passed at commit `5e25eb9`
  - CVMFS enabled, sudo enabled: `test_nonexistent_module_fails` passed; 158 passed, 3 skipped
  - CVMFS enabled, sudo disabled: `test_nonexistent_module_fails` passed; 158 passed, 3 skipped
  - both architecture builds, both image scans, all eight container profiles, and manifest publication passed
