### PR TITLE
Background the OpenCode session prune so it can't stall startup

### DIFF
--- a/config/jupyter/jupyterlab_startup.sh
+++ b/config/jupyter/jupyterlab_startup.sh
@@ -259,9 +259,19 @@ mkdir -p ${HOME}/.config/opencode
 # leaves its sessions behind pointing at a path that no longer exists, and
 # opening one replays that dead directory back into the API. Set
 # NEURODESKTOP_OPENCODE_PRUNE_SESSIONS=0 to keep every session forever.
+#
+# Detach it: on a large opencode.db the --apply path (rolling backup + delete +
+# VACUUM) is O(database size) and can take minutes. Run synchronously it delays
+# the Jupyter server bind, and JupyterHub kills the single-user pod when the
+# server does not answer within http_timeout (120s by default) - so a heavy
+# OpenCode user could never start their session. This is housekeeping the
+# server does not depend on, so background it like ensure_ssh_keys.sh and
+# ensure_codeserver_extensions above; its output goes to a log for inspection.
 if [ -x /opt/neurodesktop/opencode_prune_sessions.py ]; then
-    /opt/neurodesktop/opencode_prune_sessions.py --apply || \
-        echo "[WARN] OpenCode session prune failed; leaving session history untouched."
+    {
+        /opt/neurodesktop/opencode_prune_sessions.py --apply || \
+            echo "[WARN] OpenCode session prune failed; leaving session history untouched."
+    } >/tmp/opencode_prune_sessions.log 2>&1 &
 fi
 
 # Align Notebook Intelligence's provider/model with the model selected in

--- a/docs/architecture/coding-agents.md
+++ b/docs/architecture/coding-agents.md
@@ -112,8 +112,13 @@ paths that are gone.
 (installed as `/opt/neurodesktop/opencode_prune_sessions.py`) removes sessions
 whose working directory no longer exists.
 [`jupyterlab_startup.sh`](../../config/jupyter/jupyterlab_startup.sh) runs it with
-`--apply` once per container start; run it by hand without `--apply` for a dry
-run. `NEURODESKTOP_OPENCODE_PRUNE_SESSIONS=0` disables it.
+`--apply` once per container start, **in the background** (output to
+`/tmp/opencode_prune_sessions.log`). The `--apply` path is O(database size) - it
+writes a rolling backup and `VACUUM`s the database - so on a large
+`opencode.db` it can take minutes; detaching it keeps a slow prune from delaying
+the Jupyter server bind, which JupyterHub would otherwise kill at `http_timeout`.
+Run it by hand without `--apply` for a dry run.
+`NEURODESKTOP_OPENCODE_PRUNE_SESSIONS=0` disables it.
 
 Three details make the deletion safe and complete:
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -163,7 +163,8 @@ are listed at the end. The subsystems themselves are described in
   to keep OpenCode sessions whose working directory has been deleted. By
   default `jupyterlab_startup.sh` runs
   `/opt/neurodesktop/opencode_prune_sessions.py --apply` once per container
-  start, which drops those sessions from
+  start, in the background so a slow prune on a large database cannot delay the
+  Jupyter server bind, which drops those sessions from
   `~/.local/share/opencode/opencode.db` (OpenCode itself never prunes them, so
   they otherwise stay in its session index pointing at paths that no longer
   exist). Sessions whose whole parent tree is missing are left alone, so a

--- a/tests/unit/test_opencode_prune_sessions.py
+++ b/tests/unit/test_opencode_prune_sessions.py
@@ -236,6 +236,30 @@ def test_startup_script_runs_the_prune():
     assert "-x /opt/neurodesktop/opencode_prune_sessions.py" in text
 
 
+def test_startup_script_backgrounds_the_prune():
+    """The prune must be detached so it can never block the server bind.
+
+    On a large opencode.db the ``--apply`` path (rolling backup + delete +
+    VACUUM) is O(database size) and can take minutes. Run synchronously it
+    delays the Jupyter server bind, and JupyterHub kills the single-user pod
+    when the server does not answer within ``http_timeout`` (120s by default),
+    so a heavy OpenCode user can never start. It must run in the background.
+    """
+    startup = repo_path("config/jupyter/jupyterlab_startup.sh")
+    if not startup.is_file():
+        pytest.skip("repository checkout not available")
+    text = startup.read_text(encoding="utf-8")
+    marker = "if [ -x /opt/neurodesktop/opencode_prune_sessions.py"
+    assert marker in text, "prune invocation guard missing from startup script"
+    block = text[text.index(marker):]
+    block = block[: block.index("\nfi")]
+    assert block.rstrip().endswith("&"), (
+        "the OpenCode prune must be backgrounded (end the guard block with '&') "
+        "so a slow prune on a large opencode.db cannot stall the server bind "
+        "past http_timeout"
+    )
+
+
 def test_dockerfile_installs_the_prune_script_executable():
     """The image must ship it at the path jupyterlab_startup.sh calls."""
     text = repo_path("Dockerfile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

A heavy OpenCode user on our JupyterHub deployment could not start their Neurodesk session at all: the pod schedules, containers start, but `jupyterhub-singleuser` never binds `:8888`, so the hub times out at `http_timeout` (120s) and kills the pod — a ~40+ cycle spawn-retry loop. The notebook startup log dead-ends right after the `Checking for ARM CPU … /proc/cpuinfo` line, with no error.

## Root cause

`jupyterlab_startup.sh` runs `opencode_prune_sessions.py --apply` **synchronously** before the server starts. The `--apply` path is O(database size): when there is ≥1 stale (deleted-directory) session it writes a full rolling backup of `opencode.db` (`shutil.copy2`) and then `VACUUM`s it. This user had a **~1 GB `opencode.db`** (hundreds of benchmark sessions with since-deleted working dirs); on our storage the prune measured **~440s**, well past the 120s `http_timeout`, so the server never got to bind. It is silent (slow subprocess, no traceback) and only bites users with a large DB, so it is easy to miss.

## Fix

Background the prune, exactly like the adjacent best-effort startup tasks (`ensure_ssh_keys.sh`, `ensure_codeserver_extensions`) already are. It is housekeeping the server does not depend on, so a slow prune can no longer delay the server bind regardless of database size or storage speed. Output goes to `/tmp/opencode_prune_sessions.log`.

## Testing

`pytest tests/unit/test_opencode_prune_sessions.py` → **12 passed** (added `test_startup_script_backgrounds_the_prune`; existing behavior unchanged). Also verified on the affected deployment: running the prune once offline cleared the stale sessions, and the user's session now starts in seconds.

## Notes / possible follow-ups

- Backgrounding stops the prune blocking startup; its cost (full backup + `VACUUM` of a large DB) is otherwise unchanged. If you'd prefer, the `--apply` path could additionally skip the `VACUUM` (dominant cost, reclaims little after only a few deletions) or guard by DB size — happy to add.
- `NEURODESKTOP_OPENCODE_PRUNE_SESSIONS=0` remains the escape hatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenCode session cleanup now runs in the background during startup, allowing the Jupyter server to become available sooner.
  - Cleanup activity is recorded in `/tmp/opencode_prune_sessions.log`.

- **Bug Fixes**
  - Startup continues even if session cleanup encounters an error, while preserving session history.

- **Documentation**
  - Updated guidance explains background cleanup timing, logging, dry-run behavior, and disabling the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
