### PR TITLE
Fix nightly build: pin cvmfs-fuse3 and cvmfs-libs to CVMFS_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -340,6 +340,8 @@ RUN retry wget -q https://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_al
     && apt-install-retry \
     autofs \
     cvmfs="${CVMFS_VERSION}" \
+    cvmfs-fuse3="${CVMFS_VERSION}" \
+    cvmfs-libs="${CVMFS_VERSION}" \
     uuid-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`build-neurodesktop-test` has failed at the CVMFS apt install on both arches every night since 17 Aug. Two-line fix, no version change.

```diff
     cvmfs="${CVMFS_VERSION}" \
+    cvmfs-fuse3="${CVMFS_VERSION}" \
+    cvmfs-libs="${CVMFS_VERSION}" \
```

**Why not bump the ARG to 2.14.1** (as #835 suggests): only `cvmfs` is version-pinned, but it requires `cvmfs-fuse3` and `cvmfs-libs` at exactly the same version, and apt resolves those unpinned deps to the newest available. Bumping works until CERN ships 2.14.2, then it breaks identically. 2.13.3 was never removed. The build below downloads it fine.

**Verified:** [run 32680721768](https://github.com/neurodesk/neurodesktop/actions/runs/32680721768). `build-image` green on amd64 (Sydney ARC) and arm64 (Blacksmith), all 8 `test-image` green. Built with `no-cache: true`.

```
Get:24 ... cvmfs-libs  amd64 2.13.3+ubuntu24.04 [11.3 MB]
Get:25 ... cvmfs-fuse3 amd64 2.13.3+ubuntu24.04 [15.0 MB]
```

`scan-image` is still red on that run. Unrelated Trivy issue, tracked in #836.

Closes #833, closes #834, closes #835, closes #839, closes #841, closes #845, closes #847, closes #848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CVMFS FUSE 3 support to the runtime environment.
  * Pinned the additional CVMFS components to the configured CVMFS version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->