### PR TITLE
align collaboration frontends with JupyterLab 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -556,6 +556,8 @@ RUN retry conda install -c conda-forge nb_conda_kernels \
 ARG BUST_CACHE_PIP=3
 ARG UV_VERSION="0.12.3"
 ARG JUPYTER_AI_VERSION="3.1.2"
+ARG JUPYTER_COLLABORATION_VERSION="4.4.2"
+ARG JUPYTER_COLLABORATION_REF="3bf11cb7b271b554998105a11e6c9b8c3e376615"
 ARG ASTRA_SPEC_VERSION="0.0.12"
 ARG ASTRA_TOOLS_VERSION="0.2.11"
 ARG ANYWIDGET_VERSION="0.11.0"
@@ -598,7 +600,9 @@ RUN apt-install-retry build-essential \
     jupyterlab-chat==0.23.2 \
     jupyterlab-commands-toolkit==0.1.6 \
     jupyterlab-notebook-awareness==0.2.0 \
-    jupyter-collaboration==5.0.0 \
+    # Stay on the JupyterLab 4 collaboration line. Its published frontends
+    # need the scoped YDoc 4 rebuild below before JupyterLab 4.6 accepts them.
+    jupyter-collaboration==${JUPYTER_COLLABORATION_VERSION} \
     jupyterlab_rise \
     jupyterlab-niivue==0.2.7 \
     jupyterlab_myst==2.7.0 \
@@ -678,7 +682,7 @@ RUN apt-mark manual autofs cvmfs libc6-dev linux-libc-dev uuid-dev \
     libgpgme-dev libossp-uuid-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# The two from-source labextension rebuilds below are the most expensive
+# The three from-source labextension rebuilds below are the most expensive
 # layers in the image. They live here — before neurocommand, the local
 # extension builds, and every config/tests layer — so that config, test,
 # webapp-link, and extension churn never invalidates them; their only cache
@@ -754,6 +758,56 @@ RUN MYST_VERSION="$(/opt/conda/bin/pip show jupyterlab_myst | awk '/^Version:/ {
     && rm -rf "${APP_MYST_DIR}" \
     && cp -a "${MYST_LABEXT_DIR}" "${APP_MYST_DIR}" \
     && rm -rf /tmp/myst /tmp/rise /tmp/myst-corepack /tmp/myst-pnpm-store /home/${NB_USER}/.cache /home/${NB_USER}/.yarn
+
+# Jupyter Collaboration 4.4.2 targets JupyterLab 4, but its published
+# frontends advertise @jupyter/ydoc only through version 3 and are therefore
+# rejected by JupyterLab 4.6's YDoc 4.1.1. Rebuild only the collaboration and
+# document-provider frontends against the exact YDoc already used by the image.
+# The two casts bridge duplicate protected TypeScript identities created by
+# the workspace; they do not change runtime code or document factories.
+RUN retry git clone --depth 1 --branch "v${JUPYTER_COLLABORATION_VERSION}" \
+    https://github.com/jupyterlab/jupyter-collaboration.git /tmp/jupyter-collaboration \
+    && test "$(git -C /tmp/jupyter-collaboration rev-parse HEAD)" = "${JUPYTER_COLLABORATION_REF}" \
+    && cd /tmp/jupyter-collaboration \
+    && npm pkg set "resolutions.@jupyter/ydoc=${MYST_YDOC_VERSION}" \
+    && for package_dir in \
+    packages/collaboration-extension \
+    packages/collaborative-drive \
+    packages/docprovider-extension \
+    packages/docprovider; do \
+        npm pkg set "dependencies.@jupyter/ydoc=^${MYST_YDOC_VERSION}" --prefix "${package_dir}"; \
+    done \
+    && npm pkg set "devDependencies.@jupyterlab/builder=${NBI_JUPYTERLAB_BUILDER_VERSION}" \
+    --prefix packages/collaboration-extension \
+    && npm pkg set "devDependencies.@jupyterlab/builder=${NBI_JUPYTERLAB_BUILDER_VERSION}" \
+    --prefix packages/docprovider-extension \
+    && sed -i \
+    -e 's/^      yFileFactory$/      yFileFactory as never/' \
+    -e 's/^      yNotebookFactory$/      yNotebookFactory as never/' \
+    packages/docprovider-extension/src/filebrowser.ts \
+    && YARN_ENABLE_IMMUTABLE_INSTALLS=0 retry jlpm install \
+    && jlpm lerna run build \
+    --scope @jupyter/collaboration \
+    --scope @jupyter/collaborative-drive \
+    --scope @jupyter/docprovider \
+    && jlpm lerna run build:lib:prod \
+    && /opt/conda/bin/jupyter labextension build \
+    --core-path=/opt/conda/share/jupyter/lab packages/collaboration-extension \
+    && /opt/conda/bin/jupyter labextension build \
+    --core-path=/opt/conda/share/jupyter/lab packages/docprovider-extension \
+    && COLLAB_SRC=/tmp/jupyter-collaboration/projects/jupyter-collaboration-ui/jupyter_collaboration_ui/labextension \
+    && DOCPROVIDER_SRC=/tmp/jupyter-collaboration/projects/jupyter-docprovider/jupyter_docprovider/labextension \
+    && COLLAB_DEST=/opt/conda/share/jupyter/labextensions/@jupyter/collaboration-extension \
+    && DOCPROVIDER_DEST=/opt/conda/share/jupyter/labextensions/@jupyter/docprovider-extension \
+    && rm -rf "${COLLAB_DEST}" "${DOCPROVIDER_DEST}" \
+    && cp -a "${COLLAB_SRC}" "${COLLAB_DEST}" \
+    && cp -a "${DOCPROVIDER_SRC}" "${DOCPROVIDER_DEST}" \
+    # Strip the rebuild's sourcemaps in the layer that installs the bundles.
+    && find "${COLLAB_DEST}/static" "${DOCPROVIDER_DEST}/static" \
+    -type f \( -name "*.js.map" -o -name "*.css.map" \) -delete \
+    && test "$(node -p "require('${COLLAB_DEST}/package.json').dependencies['@jupyter/ydoc']")" = "^${MYST_YDOC_VERSION}" \
+    && test "$(node -p "require('${DOCPROVIDER_DEST}/package.json').dependencies['@jupyter/ydoc']")" = "^${MYST_YDOC_VERSION}" \
+    && rm -rf /tmp/jupyter-collaboration /root/.cache /home/${NB_USER}/.cache /home/${NB_USER}/.yarn
 
 # The layers from here to the local extension builds are keyed only on pinned
 # versions/refs (no local files), so they change on explicit bumps and never

--- a/docs/architecture/jupyter-ai.md
+++ b/docs/architecture/jupyter-ai.md
@@ -1,10 +1,10 @@
 ---
 title: Jupyter AI
 description: The ACP-native Jupyter AI chat surface, its Claude/Codex/OpenCode
-  personas, workspace seeding, and anchored server workarounds
+  personas, workspace seeding, and collaboration-stack workarounds
 parent: ../architecture.md
 status: current
-last-reviewed: "2026-08-11"
+last-reviewed: "2026-08-25"
 ---
 
 # Jupyter AI
@@ -65,11 +65,12 @@ registration site; a different hook overriding ours still warns.
 
 ## Collaboration stack and server workarounds
 
-Jupyter AI 3.1.2 is installed with Jupyter Collaboration 5.0.0. Its published
-collaboration and document-provider frontends support the JupyterLab 4.6 YDoc
-4.1.1 contract directly, so Neurodesktop no longer rebuilds those two bundles.
-The image test requires both published extensions to report `OK` in
-`jupyter labextension list --verbose`.
+Jupyter AI 3.1.2 is installed with Jupyter Collaboration 4.4.2. The release
+targets JupyterLab 4, but its published collaboration and document-provider
+frontends support `@jupyter/ydoc` only through version 3. Neurodesktop rebuilds
+those two bundles against the image's JupyterLab 4.6 YDoc 4.1.1 contract. The
+image test requires both rebuilt extensions to report `OK` in `jupyter
+labextension list --verbose`.
 
 `jupyter-server-documents` 0.3.3 still has an upstream stale-client race in which one
 queued update can terminate a chat room's background message processor.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,7 +4,7 @@ description: Reference for runtime environment variables and Dockerfile build
   arguments supported by Neurodesktop
 parent: index.md
 status: current
-last-reviewed: "2026-08-11"
+last-reviewed: "2026-08-25"
 ---
 
 # Environment Variables
@@ -201,7 +201,7 @@ reviewed; the Dockerfile itself is authoritative.
   defaults to `4ded682be8487d8aa05831678ef84ef12068d50d`
 - `JUPYTER_AI_VERSION`: Jupyter AI metapackage release;
   defaults to `3.1.2`, with its direct pre-1.0 extensions and Jupyter
-  Collaboration 5.0.0 pinned alongside it
+  Collaboration pinned alongside it
 - `CODEX_ACP_VERSION`, `CLAUDE_AGENT_ACP_VERSION`: pinned
   ACP adapters that expose the Codex and Claude personas in Jupyter AI;
   defaults to `1.1.14` and `0.66.0`. They install without their vendored agent
@@ -211,6 +211,10 @@ reviewed; the Dockerfile itself is authoritative.
 - `CODEX_CLI_VERSION`: the `@openai/codex` CLI release
   installed globally; defaults to `0.147.0` and must stay inside the range the
   pinned codex-acp adapter declares, because the adapter drives this binary
+- `JUPYTER_COLLABORATION_VERSION`, `JUPYTER_COLLABORATION_REF`: release and
+  exact source commit used to rebuild Jupyter AI's collaboration frontends for
+  JupyterLab 4.6's YDoc 4 contract; defaults to `4.4.2` and
+  `3bf11cb7b271b554998105a11e6c9b8c3e376615`
 - `MYST_PNPM_VERSION`, `MYST_YDOC_VERSION`: pnpm and Jupyter
   YDoc releases used for the MyST/RISE compatibility rebuild; defaults to
   `11.21.0` and `4.1.1`

--- a/tests/container/test_astra_jupyter_ai_image.py
+++ b/tests/container/test_astra_jupyter_ai_image.py
@@ -196,8 +196,8 @@ def test_jupyter_ai_server_and_frontend_extensions_are_compatible():
 
     code, lab_output = run_cmd("jupyter labextension list --verbose", timeout=60)
     assert code == 0, lab_output
-    assert "@jupyter/collaboration-extension v5.0.0" in lab_output
-    assert "@jupyter/docprovider-extension v5.0.0" in lab_output
+    assert "@jupyter/collaboration-extension v4.4.2" in lab_output
+    assert "@jupyter/docprovider-extension v4.4.2" in lab_output
     assert "not compatible with the current JupyterLab" not in lab_output
 
 

--- a/tests/unit/test_astra_jupyter_ai_tooling.py
+++ b/tests/unit/test_astra_jupyter_ai_tooling.py
@@ -176,8 +176,30 @@ def test_upstream_checkouts_are_pinned_to_an_exact_commit():
     exist: a reference that disappears has to fail here rather than reduce
     this to a vacuous pass.
     """
-    references = ["AGENT_SKILLS_REF"]
+    references = ["AGENT_SKILLS_REF", "JUPYTER_COLLABORATION_REF"]
 
     for reference in references:
         assert f"ARG {reference}=" in DOCKERFILE, reference
         assert f'rev-parse HEAD)" = "${{{reference}}}"' in DOCKERFILE, reference
+
+
+def test_collaboration_frontends_are_rebuilt_for_jupyterlab_46_ydoc():
+    """The 4.x wheels exclude YDoc 4 even though they target JupyterLab 4."""
+    assert 'ARG JUPYTER_COLLABORATION_VERSION="4.4.2"' in DOCKERFILE
+    assert (
+        "jupyter-collaboration==${JUPYTER_COLLABORATION_VERSION}" in DOCKERFILE
+    )
+    assert (
+        'npm pkg set "resolutions.@jupyter/ydoc=${MYST_YDOC_VERSION}"'
+        in DOCKERFILE
+    )
+    assert "packages/collaboration-extension" in DOCKERFILE
+    assert "packages/docprovider-extension" in DOCKERFILE
+    assert (
+        "COLLAB_DEST=/opt/conda/share/jupyter/labextensions/"
+        "@jupyter/collaboration-extension" in DOCKERFILE
+    )
+    assert (
+        "DOCPROVIDER_DEST=/opt/conda/share/jupyter/labextensions/"
+        "@jupyter/docprovider-extension" in DOCKERFILE
+    )


### PR DESCRIPTION
## Summary

- Pin Jupyter Collaboration 4.4.2 and rebuild its collaboration/document-provider frontends against YDoc 4.1.1.
- Update compatibility tests and documentation for the JupyterLab 4 collaboration stack.
- Run OpenCode stale-session pruning automatically at container startup, with an opt-out variable.
- Remove the obsolete widget compatibility image test and related vulnerability ignores.

## Testing

- Added/updated unit coverage for collaboration frontend rebuilding and startup session pruning.
- Not run: full unit suite.
- Not run: built-image validation (`pytest /opt/tests/test_astra_jupyter_ai_image.py`, `pip check`, Jupyter extension listings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Jupyter Collaboration compatibility with JupyterLab 4.6 and YDoc 4.1.1.
  - Updated collaboration extensions to version 4.4.2.

- **Documentation**
  - Documented the supported collaboration version, source revision, and compatibility requirements.
  - Updated frontend rebuild guidance.

- **Tests**
  - Added validation for collaboration package versions, dependency resolution, and installed extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->