### PR TITLE
Fix stale CVMFS action cache

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
 # CodeRabbit configuration
 # Reference: https://docs.coderabbit.ai/reference/yaml-template
 reviews:
+  review_status: false
+  in_progress_fortune: false
   auto_review:
     enabled: true
     # Agentic workflows open draft pull requests so review must start before

--- a/.github/workflows/build-neurodesktop-dev.yml
+++ b/.github/workflows/build-neurodesktop-dev.yml
@@ -253,7 +253,7 @@ jobs:
         run: docker pull "$IMAGEID:latest"
       - name: Initialize CVMFS
         if: matrix.needs_cvmfs
-        uses: cvmfs-contrib/github-action-cvmfs@v3
+        uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
       - name: Configure Neurodesk CVMFS
         if: matrix.needs_cvmfs
         run: |

--- a/.github/workflows/build-neurodesktop-test.yml
+++ b/.github/workflows/build-neurodesktop-test.yml
@@ -432,7 +432,7 @@ jobs:
         run: docker pull "$IMAGE_REF"
       - name: Initialize CVMFS
         if: matrix.profile.needs_cvmfs
-        uses: cvmfs-contrib/github-action-cvmfs@v3
+        uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
       - name: Configure Neurodesk CVMFS
         if: matrix.profile.needs_cvmfs
         run: |

--- a/.github/workflows/build-neurodesktop.yml
+++ b/.github/workflows/build-neurodesktop.yml
@@ -398,7 +398,7 @@ jobs:
         run: docker pull "$IMAGEID:amd64"
       - name: Initialize CVMFS
         if: matrix.needs_cvmfs
-        uses: cvmfs-contrib/github-action-cvmfs@v3
+        uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
       - name: Configure Neurodesk CVMFS
         if: matrix.needs_cvmfs
         run: |

--- a/tests/unit/test_build_neurodesktop_workflow.py
+++ b/tests/unit/test_build_neurodesktop_workflow.py
@@ -7,6 +7,15 @@ from testlib import repo_path
 
 
 WORKFLOW = repo_path(".github/workflows/build-neurodesktop.yml")
+IMAGE_TEST_WORKFLOWS = (
+    WORKFLOW,
+    repo_path(".github/workflows/build-neurodesktop-dev.yml"),
+    repo_path(".github/workflows/build-neurodesktop-test.yml"),
+)
+CVMFS_ACTION = (
+    "cvmfs-contrib/github-action-cvmfs@"
+    "10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5"
+)
 
 
 def _tag_step(workflow):
@@ -91,6 +100,14 @@ def test_production_build_checkouts_stay_on_the_run_sha():
     assert checkout_count > 0
     assert workflow.count("ref: ${{ github.sha }}") == checkout_count
     assert "ref: ${{ github.ref }}" not in workflow
+
+
+def test_image_tests_use_cvmfs_action_without_stale_apt_package_lists():
+    for workflow_path in IMAGE_TEST_WORKFLOWS:
+        workflow = workflow_path.read_text()
+
+        assert CVMFS_ACTION in workflow
+        assert "github-action-cvmfs@v3" not in workflow
 
 
 def test_production_build_updates_the_date_tag_without_deleting_it():


### PR DESCRIPTION
The CVMFS-enabled image tests failed when the v3 setup action restored stale APT package lists, causing an attr/libattr1 dependency conflict and leaving cvmfs_config uninstalled.

Pin all three image workflows to the v5.5 action commit. This release disables caching APT package lists by default. Add a focused guard covering the three workflow references.

Disable CodeRabbit review status comments and in-progress fortune messages to reduce review-start notifications. Review findings and check statuses remain enabled.

Validation: the focused check failed before the change, all seven build-workflow unit tests passed afterward, and all three workflow YAML files parsed successfully. The full PR unit suite and analysis checks passed. The development image rebuild passed, including both CVMFS profiles, all other container profiles, and the security scan: https://github.com/neurodesk/neurodesktop/actions/runs/33942867534.

CodeRabbit reviewed the CVMFS fix without actionable findings. Its follow-up review of the notification configuration was rate-limited; that configuration passed validation against CodeRabbit's official schema.
